### PR TITLE
Refine setuptools packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+recursive-include src *.py

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PYTHON_FILES := sonos_lastfm.py utils.py
 
 # Install development dependencies
 install-dev:
-	uv pip install mypy ruff types-setuptools hatchling
+	uv pip install build mypy ruff setuptools wheel types-setuptools
 
 # Check types with mypy
 check-types:
@@ -72,8 +72,8 @@ update-version:
 # Build Python package
 build-package:
 	@echo "Building package..."
-	uv pip install hatchling
-	uv build --no-sources
+	uv pip install build
+	uv run --with build python -m build --wheel --sdist
 
 # Publish package to PyPI
 publish-package:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "soco-scribbler"
 version = "0.1.5"
 description = "Automatically scribble what's playing on your Sonos speakers. Pus to services like Last.fm, and others."
-readme = "README.md"
+readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "Denis Moskalets", email = "denya.msk@gmail.com" },
     { name = "Brian M. Dennis", email = "bmd@pirateninja.dev" }
 ]
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 keywords = ["sonos", "lastfm", "scrobbler", "music", "sqlite"]
 classifiers = [
@@ -42,18 +42,16 @@ Issues = "https://github.com/crossjam/soco-scribbler/issues"
 sonos-lastfm = "soco_scribbler:main"
 soco-scribbler = "soco_scribbler.soco_scribbler:main"
 
-[tool.hatch.build]
-include = [
-    "src/soco_scribbler/*.py",
-    "LICENSE",
-    "README.md"
-]
+[tool.setuptools]
+package-dir = { "" = "src" }
+license-files = ["LICENSE"]
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/soco_scribbler"]
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["soco_scribbler"]
 
 [tool.mypy]
-python_version = "0.1.5"
+python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
## Summary
- ensure the setuptools configuration declares the src layout, limits package discovery, references the README and license files, and ships the license file
- add a MANIFEST.in so the README, license, and sources are included alongside setuptools builds
- update the Makefile helpers to install the build frontend and invoke python -m build via uv
- correct the metadata by declaring the README content type and restoring mypy's target Python version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690254001bb4832fa628aa0c46218b76